### PR TITLE
Allow to register request-scoped JAX-RS resources

### DIFF
--- a/integration-test/launchpad-test/pom.xml
+++ b/integration-test/launchpad-test/pom.xml
@@ -82,7 +82,7 @@
     <dependency>
       <groupId>io.wcm.caravan</groupId>
       <artifactId>io.wcm.caravan.jaxrs.publisher</artifactId>
-      <version>1.1.1-SNAPSHOT</version>
+      <version>1.2.0-SNAPSHOT</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/integration-test/launchpad-test/src/test/java/io/wcm/caravan/jaxrs/publisher/it/JaxRsGetIT.java
+++ b/integration-test/launchpad-test/src/test/java/io/wcm/caravan/jaxrs/publisher/it/JaxRsGetIT.java
@@ -19,7 +19,11 @@
  */
 package io.wcm.caravan.jaxrs.publisher.it;
 
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 
 import java.io.IOException;
 
@@ -29,7 +33,9 @@ import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.DefaultHttpClient;
 import org.apache.http.util.EntityUtils;
+import org.hamcrest.Matchers;
 import org.junit.Test;
+import org.mockito.ArgumentMatchers;
 
 public class JaxRsGetIT {
 
@@ -64,6 +70,20 @@ public class JaxRsGetIT {
         "/caravan/jaxrs/test/sampleservice2", "text/plain");
   }
 
+  @Test
+  public void testSampleService2RequestScoped() throws Exception {
+    String dateUri = "/caravan/jaxrs/test/sampleservice2/date";
+
+    // verify that the resource is able to get the serviceId from the JaxRsComponent
+    String response1 = getResponseBody(dateUri);
+    assertThat(response1, startsWith("/caravan/jaxrs/test/sampleservice2"));
+
+    // verify that the resource is actually request-scoped (by checking that the time in the response changes)
+    Thread.sleep(2000);
+    String response2 = getResponseBody(dateUri);
+    assertThat(response1, not(equalTo(response2)));
+  }
+
   private void assertResponse(String url, String expectedResponse, String expectedContentType) throws IOException {
     String fullUrl = SERVER_URL + url;
     HttpGet get = new HttpGet(fullUrl);
@@ -78,6 +98,14 @@ public class JaxRsGetIT {
     HttpGet get = new HttpGet(fullUrl);
     HttpResponse response = new DefaultHttpClient().execute(get);
     assertEquals("Response code for " + fullUrl, HttpServletResponse.SC_NOT_FOUND, response.getStatusLine().getStatusCode());
+  }
+
+  private String getResponseBody(String url) throws IOException {
+    String fullUrl = SERVER_URL + url;
+    HttpGet get = new HttpGet(fullUrl);
+    HttpResponse response = new DefaultHttpClient().execute(get);
+    assertEquals("Response code for " + fullUrl, HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
+    return EntityUtils.toString(response.getEntity());
   }
 
 }

--- a/integration-test/sample-service-1/pom.xml
+++ b/integration-test/sample-service-1/pom.xml
@@ -41,7 +41,7 @@
     <dependency>
       <groupId>io.wcm.caravan</groupId>
       <artifactId>io.wcm.caravan.jaxrs.publisher</artifactId>
-      <version>1.1.1-SNAPSHOT</version>
+      <version>1.2.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
 

--- a/integration-test/sample-service-2/pom.xml
+++ b/integration-test/sample-service-2/pom.xml
@@ -34,14 +34,14 @@
   <version>1-SNAPSHOT</version>
   <packaging>bundle</packaging>
 
-  <name>JAX-RS Integration Test Sample Service 1</name>
+  <name>JAX-RS Integration Test Sample Service 2</name>
 
   <dependencies>
 
     <dependency>
       <groupId>io.wcm.caravan</groupId>
       <artifactId>io.wcm.caravan.jaxrs.publisher</artifactId>
-      <version>1.1.1-SNAPSHOT</version>
+      <version>1.2.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
 

--- a/integration-test/sample-service-2/src/main/java/io/wcm/caravan/jaxrs/publisher/sampleservice2/JaxRsClassesProviderService.java
+++ b/integration-test/sample-service-2/src/main/java/io/wcm/caravan/jaxrs/publisher/sampleservice2/JaxRsClassesProviderService.java
@@ -19,32 +19,25 @@
  */
 package io.wcm.caravan.jaxrs.publisher.sampleservice2;
 
-import java.text.DateFormat;
-import java.util.Date;
+import java.util.Set;
 
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.Context;
+import org.apache.felix.scr.annotations.Component;
+import org.apache.felix.scr.annotations.Service;
+
+import com.google.common.collect.ImmutableSet;
+
+import io.wcm.caravan.jaxrs.publisher.JaxRsClassesProvider;
 
 /**
- * Sample request-scoped data resource.
+ * Sample JAX-RS classes provider.
  */
-@Path("/date")
-public class RequestScopeDateResource {
+@Component(immediate = true)
+@Service(JaxRsClassesProvider.class)
+public class JaxRsClassesProviderService implements JaxRsClassesProvider {
 
-  private final String date = DateFormat.getDateTimeInstance().format(new Date());
-
-  @Context
-  private JaxRsService service;
-
-  /**
-   * @return the current date
-   */
-  @GET
-  @Produces("text/plain")
-  public String getDate() {
-    return service.getServiceId() + " knows it's " + date;
+  @Override
+  public Set<Class<?>> getClasses() {
+    return ImmutableSet.of(RequestScopeDateResource.class);
   }
 
 }

--- a/integration-test/sample-service-2/src/main/java/io/wcm/caravan/jaxrs/publisher/sampleservice2/JaxRsService.java
+++ b/integration-test/sample-service-2/src/main/java/io/wcm/caravan/jaxrs/publisher/sampleservice2/JaxRsService.java
@@ -19,8 +19,7 @@
  */
 package io.wcm.caravan.jaxrs.publisher.sampleservice2;
 
-import io.wcm.caravan.jaxrs.publisher.ApplicationPath;
-import io.wcm.caravan.jaxrs.publisher.JaxRsComponent;
+import java.util.Collection;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
@@ -30,6 +29,11 @@ import org.apache.felix.scr.annotations.Activate;
 import org.apache.felix.scr.annotations.Component;
 import org.apache.felix.scr.annotations.Service;
 import org.osgi.service.component.ComponentContext;
+
+import com.google.common.collect.ImmutableSet;
+
+import io.wcm.caravan.jaxrs.publisher.ApplicationPath;
+import io.wcm.caravan.jaxrs.publisher.JaxRsComponent;
 
 /**
  * Sample JAX-RS Service
@@ -44,6 +48,10 @@ public class JaxRsService implements JaxRsComponent {
   @Activate
   protected void activate(ComponentContext componentContext) {
     serviceId = ApplicationPath.get(componentContext);
+  }
+
+  public Collection<Class<?>> getAdditionalJaxRsClassesToRegister() {
+    return ImmutableSet.of(RequestScopeDateResource.class);
   }
 
   /**

--- a/integration-test/sample-service-2/src/main/java/io/wcm/caravan/jaxrs/publisher/sampleservice2/JaxRsService.java
+++ b/integration-test/sample-service-2/src/main/java/io/wcm/caravan/jaxrs/publisher/sampleservice2/JaxRsService.java
@@ -19,8 +19,6 @@
  */
 package io.wcm.caravan.jaxrs.publisher.sampleservice2;
 
-import java.util.Collection;
-
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
@@ -29,8 +27,6 @@ import org.apache.felix.scr.annotations.Activate;
 import org.apache.felix.scr.annotations.Component;
 import org.apache.felix.scr.annotations.Service;
 import org.osgi.service.component.ComponentContext;
-
-import com.google.common.collect.ImmutableSet;
 
 import io.wcm.caravan.jaxrs.publisher.ApplicationPath;
 import io.wcm.caravan.jaxrs.publisher.JaxRsComponent;
@@ -48,10 +44,6 @@ public class JaxRsService implements JaxRsComponent {
   @Activate
   protected void activate(ComponentContext componentContext) {
     serviceId = ApplicationPath.get(componentContext);
-  }
-
-  public Collection<Class<?>> getAdditionalJaxRsClassesToRegister() {
-    return ImmutableSet.of(RequestScopeDateResource.class);
   }
 
   /**

--- a/integration-test/sample-service-2/src/main/java/io/wcm/caravan/jaxrs/publisher/sampleservice2/RequestScopeDateResource.java
+++ b/integration-test/sample-service-2/src/main/java/io/wcm/caravan/jaxrs/publisher/sampleservice2/RequestScopeDateResource.java
@@ -1,0 +1,27 @@
+package io.wcm.caravan.jaxrs.publisher.sampleservice2;
+
+import java.text.DateFormat;
+import java.util.Date;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+
+@Path("/date")
+public class RequestScopeDateResource {
+
+  private final String date = DateFormat.getDateTimeInstance().format(new Date());
+
+  @Context
+  private JaxRsService service;
+
+  /**
+   * @return the current date
+   */
+  @GET
+  @Produces("text/plain")
+  public String getDate() {
+    return service.getServiceId() + " knows it's " + date;
+  }
+}

--- a/publisher/pom.xml
+++ b/publisher/pom.xml
@@ -31,7 +31,7 @@
 
   <groupId>io.wcm.caravan</groupId>
   <artifactId>io.wcm.caravan.jaxrs.publisher</artifactId>
-  <version>1.1.1-SNAPSHOT</version>
+  <version>1.2.0-SNAPSHOT</version>
   <packaging>bundle</packaging>
 
   <name>JAX-RS Publisher</name>

--- a/publisher/src/main/java/io/wcm/caravan/jaxrs/publisher/ApplicationPath.java
+++ b/publisher/src/main/java/io/wcm/caravan/jaxrs/publisher/ApplicationPath.java
@@ -19,6 +19,7 @@
  */
 package io.wcm.caravan.jaxrs.publisher;
 
+import org.osgi.annotation.versioning.ProviderType;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 import org.osgi.service.component.ComponentContext;
@@ -26,6 +27,7 @@ import org.osgi.service.component.ComponentContext;
 /**
  * Gets JAX-RS application path (URI prefix) from OSGi header of the current bundle.
  */
+@ProviderType
 public final class ApplicationPath {
 
   /**

--- a/publisher/src/main/java/io/wcm/caravan/jaxrs/publisher/JaxRsClassesProvider.java
+++ b/publisher/src/main/java/io/wcm/caravan/jaxrs/publisher/JaxRsClassesProvider.java
@@ -1,0 +1,47 @@
+/*
+ * #%L
+ * wcm.io
+ * %%
+ * Copyright (C) 2019 wcm.io
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package io.wcm.caravan.jaxrs.publisher;
+
+import java.util.Set;
+
+import org.osgi.annotation.versioning.ConsumerType;
+
+/**
+ * Allows to register additional root resource, provider and {@link javax.ws.rs.core.Feature} classes
+ * to the JAX-RS runtime.
+ * <p>
+ * These classes do not have to implement {@link JaxRsClassesProvider} and should not
+ * be OSGI components (as their lifecycle and dependency injection is completely managed by JAX-RS).
+ * </p>
+ * <p>
+ * This allows to implement request-scoped resources with constructor initialization. Since OSGI's
+ * dependency injection is not possible for these instances, other singleton {@link JaxRsClassesProvider} dependencies
+ * can be injected with the {@link javax.ws.rs.core.Context} annotation instead.
+ * </p>
+ */
+@ConsumerType
+public interface JaxRsClassesProvider {
+
+  /**
+   * @return a set of classes to be returned by JAX-RS {@link javax.ws.rs.core.Application#getClasses()}.
+   */
+  Set<Class<?>> getClasses();
+
+}

--- a/publisher/src/main/java/io/wcm/caravan/jaxrs/publisher/JaxRsComponent.java
+++ b/publisher/src/main/java/io/wcm/caravan/jaxrs/publisher/JaxRsComponent.java
@@ -36,7 +36,16 @@ public interface JaxRsComponent {
    */
   String PROPERTY_GLOBAL_COMPONENT = "caravan.jaxrs.global";
 
-  default Collection<Class<?>> getChildComponentClasses() {
+  /**
+   * Can be implemented by any JaxRsComponent to register additional root resource, provider and
+   * {@link javax.ws.rs.core.Feature} classes to the JAX-RS runtime. These classes do not have to implement
+   * {@link JaxRsComponent} and should not be OSGI components (as their lifecycle and dependency injection is completely
+   * managed by JAX-RS). This allows to implement request-scoped resources with constructor initialization. Since OSGI's
+   * dependency injection is not possible for these instances, other singleton {@link JaxRsComponent} dependencies
+   * can be injected with the {@link javax.ws.rs.core.Context} annotation instead.
+   * @return a collection of classes to be returned by JAX-RS {@link javax.ws.rs.core.Application#getClasses()}
+   */
+  default Collection<Class<?>> getAdditionalJaxRsClassesToRegister() {
     return Collections.emptyList();
   }
 }

--- a/publisher/src/main/java/io/wcm/caravan/jaxrs/publisher/JaxRsComponent.java
+++ b/publisher/src/main/java/io/wcm/caravan/jaxrs/publisher/JaxRsComponent.java
@@ -19,13 +19,14 @@
  */
 package io.wcm.caravan.jaxrs.publisher;
 
-import java.util.Collection;
-import java.util.Collections;
+import org.osgi.annotation.versioning.ConsumerType;
 
 /**
- * Marker interface that have to implement all JAX-RS services and providers.
+ * Marker interface that is implemented by all JAX-RS services and providers
+ * that are also OSGi components.
  */
 //CHECKSTYLE:OFF
+@ConsumerType
 public interface JaxRsComponent {
   //CHECKSTYLE:ON
 
@@ -36,16 +37,4 @@ public interface JaxRsComponent {
    */
   String PROPERTY_GLOBAL_COMPONENT = "caravan.jaxrs.global";
 
-  /**
-   * Can be implemented by any JaxRsComponent to register additional root resource, provider and
-   * {@link javax.ws.rs.core.Feature} classes to the JAX-RS runtime. These classes do not have to implement
-   * {@link JaxRsComponent} and should not be OSGI components (as their lifecycle and dependency injection is completely
-   * managed by JAX-RS). This allows to implement request-scoped resources with constructor initialization. Since OSGI's
-   * dependency injection is not possible for these instances, other singleton {@link JaxRsComponent} dependencies
-   * can be injected with the {@link javax.ws.rs.core.Context} annotation instead.
-   * @return a collection of classes to be returned by JAX-RS {@link javax.ws.rs.core.Application#getClasses()}
-   */
-  default Collection<Class<?>> getAdditionalJaxRsClassesToRegister() {
-    return Collections.emptyList();
-  }
 }

--- a/publisher/src/main/java/io/wcm/caravan/jaxrs/publisher/JaxRsComponent.java
+++ b/publisher/src/main/java/io/wcm/caravan/jaxrs/publisher/JaxRsComponent.java
@@ -19,6 +19,9 @@
  */
 package io.wcm.caravan.jaxrs.publisher;
 
+import java.util.Collection;
+import java.util.Collections;
+
 /**
  * Marker interface that have to implement all JAX-RS services and providers.
  */
@@ -33,4 +36,7 @@ public interface JaxRsComponent {
    */
   String PROPERTY_GLOBAL_COMPONENT = "caravan.jaxrs.global";
 
+  default Collection<Class<?>> getChildComponentClasses() {
+    return Collections.emptyList();
+  }
 }

--- a/publisher/src/main/java/io/wcm/caravan/jaxrs/publisher/impl/JaxRsApplication.java
+++ b/publisher/src/main/java/io/wcm/caravan/jaxrs/publisher/impl/JaxRsApplication.java
@@ -21,6 +21,8 @@ package io.wcm.caravan.jaxrs.publisher.impl;
 
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import javax.ws.rs.core.Application;
 
@@ -56,6 +58,15 @@ class JaxRsApplication extends Application {
   @Override
   public Set<Object> getSingletons() {
     return Sets.union(globalComponents, localComponents);
+  }
+
+  @Override
+  public Set<Class<?>> getClasses() {
+
+    return Stream.concat(localComponents.stream(), globalComponents.stream())
+        .flatMap(component -> component.getChildComponentClasses().stream())
+        .collect(Collectors.toSet());
+
   }
 
   @Override

--- a/publisher/src/main/java/io/wcm/caravan/jaxrs/publisher/impl/JaxRsApplication.java
+++ b/publisher/src/main/java/io/wcm/caravan/jaxrs/publisher/impl/JaxRsApplication.java
@@ -31,6 +31,7 @@ import org.glassfish.jersey.server.ServerProperties;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Sets;
 
+import io.wcm.caravan.jaxrs.publisher.JaxRsClassesProvider;
 import io.wcm.caravan.jaxrs.publisher.JaxRsComponent;
 
 /**
@@ -49,10 +50,15 @@ class JaxRsApplication extends Application {
 
   private final Set<JaxRsComponent> localComponents;
   private final Set<JaxRsComponent> globalComponents;
+  private Set<JaxRsClassesProvider> localClassesProviders;
+  private Set<JaxRsClassesProvider> globalClassesProviders;
 
-  JaxRsApplication(Set<JaxRsComponent> localComponents, Set<JaxRsComponent> globalComponents) {
+  JaxRsApplication(Set<JaxRsComponent> localComponents, Set<JaxRsComponent> globalComponents,
+      Set<JaxRsClassesProvider> localClassesProviders, Set<JaxRsClassesProvider> globalClassesProviders) {
     this.localComponents = localComponents;
     this.globalComponents = globalComponents;
+    this.localClassesProviders = localClassesProviders;
+    this.globalClassesProviders = globalClassesProviders;
   }
 
   @Override
@@ -62,9 +68,8 @@ class JaxRsApplication extends Application {
 
   @Override
   public Set<Class<?>> getClasses() {
-
-    return Stream.concat(localComponents.stream(), globalComponents.stream())
-        .flatMap(component -> component.getAdditionalJaxRsClassesToRegister().stream())
+    return Stream.concat(localClassesProviders.stream(), globalClassesProviders.stream())
+        .flatMap(component -> component.getClasses().stream())
         .collect(Collectors.toSet());
   }
 

--- a/publisher/src/main/java/io/wcm/caravan/jaxrs/publisher/impl/JaxRsApplication.java
+++ b/publisher/src/main/java/io/wcm/caravan/jaxrs/publisher/impl/JaxRsApplication.java
@@ -64,9 +64,8 @@ class JaxRsApplication extends Application {
   public Set<Class<?>> getClasses() {
 
     return Stream.concat(localComponents.stream(), globalComponents.stream())
-        .flatMap(component -> component.getChildComponentClasses().stream())
+        .flatMap(component -> component.getAdditionalJaxRsClassesToRegister().stream())
         .collect(Collectors.toSet());
-
   }
 
   @Override

--- a/publisher/src/main/java/io/wcm/caravan/jaxrs/publisher/impl/JaxRsClassesProviderTracker.java
+++ b/publisher/src/main/java/io/wcm/caravan/jaxrs/publisher/impl/JaxRsClassesProviderTracker.java
@@ -1,0 +1,83 @@
+/*
+ * #%L
+ * wcm.io
+ * %%
+ * Copyright (C) 2019 wcm.io
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package io.wcm.caravan.jaxrs.publisher.impl;
+
+import static io.wcm.caravan.jaxrs.publisher.impl.ServletContainerBridge.isJaxRsGlobal;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceReference;
+import org.osgi.util.tracker.ServiceTracker;
+
+import io.wcm.caravan.jaxrs.publisher.JaxRsClassesProvider;
+
+/**
+ * Tracks {@link JaxRsClassesProvider} instances.
+ */
+class JaxRsClassesProviderTracker extends ServiceTracker<JaxRsClassesProvider, Object> {
+
+  private final ServletContainerBridge bridge;
+  private final BundleContext bundleContext;
+  private final Bundle bundle;
+
+  JaxRsClassesProviderTracker(ServletContainerBridge bridge) {
+    super(bridge.getBundleContext(), JaxRsClassesProvider.class, null);
+    this.bridge = bridge;
+    this.bundleContext = bridge.getBundleContext();
+    this.bundle = bridge.getBundle();
+  }
+
+  @Override
+  public Object addingService(ServiceReference<JaxRsClassesProvider> reference) {
+    if (isJaxRsGlobal(reference)) {
+      JaxRsClassesProvider serviceInstance = bundle.getBundleContext().getService(reference);
+      ServletContainerBridge.log.debug("Register global classes provider {} for {}", serviceInstance.getClass().getName(), bundle.getSymbolicName());
+      bridge.getGlobalClassesProviders().add(serviceInstance);
+      bridge.markAsDirty();
+    }
+    else if (reference.getBundle() == bundle) {
+      JaxRsClassesProvider serviceInstance = bundle.getBundleContext().getService(reference);
+      ServletContainerBridge.log.debug("Register classes provider {} for {}", serviceInstance.getClass().getName(), bundle.getSymbolicName());
+      bridge.getLocalClassesProviders().add(serviceInstance);
+      bridge.markAsDirty();
+    }
+    return super.addingService(reference);
+  }
+
+  @Override
+  public void removedService(ServiceReference<JaxRsClassesProvider> reference, Object service) {
+    if (isJaxRsGlobal(reference)) {
+      JaxRsClassesProvider serviceInstance = bundle.getBundleContext().getService(reference);
+      ServletContainerBridge.log.debug("Unregister global classes provider {} for {}", serviceInstance.getClass().getName(), bundle.getSymbolicName());
+      bridge.getGlobalClassesProviders().remove(serviceInstance);
+      bundleContext.ungetService(reference);
+      bridge.markAsDirty();
+    }
+    else if (reference.getBundle() == bundle) {
+      JaxRsClassesProvider serviceInstance = bundle.getBundleContext().getService(reference);
+      ServletContainerBridge.log.debug("Unregister classes provider {} for {}", serviceInstance.getClass().getName(), bundle.getSymbolicName());
+      bridge.getLocalClassesProviders().remove(serviceInstance);
+      bundleContext.ungetService(reference);
+      bridge.markAsDirty();
+    }
+    super.removedService(reference, service);
+  }
+
+}

--- a/publisher/src/main/java/io/wcm/caravan/jaxrs/publisher/impl/JaxRsComponentTracker.java
+++ b/publisher/src/main/java/io/wcm/caravan/jaxrs/publisher/impl/JaxRsComponentTracker.java
@@ -1,0 +1,105 @@
+/*
+ * #%L
+ * wcm.io
+ * %%
+ * Copyright (C) 2019 wcm.io
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package io.wcm.caravan.jaxrs.publisher.impl;
+
+import static io.wcm.caravan.jaxrs.publisher.impl.ServletContainerBridge.isJaxRsGlobal;
+
+import javax.ws.rs.Path;
+import javax.ws.rs.container.PreMatching;
+import javax.ws.rs.ext.Provider;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceReference;
+import org.osgi.util.tracker.ServiceTracker;
+
+import io.wcm.caravan.jaxrs.publisher.JaxRsComponent;
+
+/**
+ * Tracks {@link JaxRsComponent} instances.
+ */
+class JaxRsComponentTracker extends ServiceTracker<JaxRsComponent, Object> {
+
+  private final ServletContainerBridge bridge;
+  private final BundleContext bundleContext;
+  private final Bundle bundle;
+
+  JaxRsComponentTracker(ServletContainerBridge bridge) {
+    super(bridge.getBundleContext(), JaxRsComponent.class, null);
+    this.bridge = bridge;
+    this.bundleContext = bridge.getBundleContext();
+    this.bundle = bridge.getBundle();
+  }
+
+  @Override
+  public Object addingService(ServiceReference<JaxRsComponent> reference) {
+    if (isJaxRsGlobal(reference)) {
+      JaxRsComponent serviceInstance = bundle.getBundleContext().getService(reference);
+      if (isJaxRsComponent(serviceInstance)) {
+        ServletContainerBridge.log.debug("Register global component {} for {}", serviceInstance.getClass().getName(), bundle.getSymbolicName());
+        bridge.getGlobalComponents().add(serviceInstance);
+        bridge.markAsDirty();
+      }
+    }
+    else if (reference.getBundle() == bundle) {
+      JaxRsComponent serviceInstance = bundle.getBundleContext().getService(reference);
+      if (isJaxRsComponent(serviceInstance)) {
+        ServletContainerBridge.log.debug("Register component {} for {}", serviceInstance.getClass().getName(), bundle.getSymbolicName());
+        bridge.getLocalComponents().add(serviceInstance);
+        bridge.markAsDirty();
+      }
+    }
+    return super.addingService(reference);
+  }
+
+  @Override
+  public void removedService(ServiceReference<JaxRsComponent> reference, Object service) {
+    if (isJaxRsGlobal(reference)) {
+      JaxRsComponent serviceInstance = bundle.getBundleContext().getService(reference);
+      if (isJaxRsComponent(serviceInstance)) {
+        ServletContainerBridge.log.debug("Unregister global component {} for {}", serviceInstance.getClass().getName(), bundle.getSymbolicName());
+        bridge.getGlobalComponents().remove(serviceInstance);
+        bundleContext.ungetService(reference);
+        bridge.markAsDirty();
+      }
+    }
+    else if (reference.getBundle() == bundle) {
+      JaxRsComponent serviceInstance = bundle.getBundleContext().getService(reference);
+      if (isJaxRsComponent(serviceInstance)) {
+        ServletContainerBridge.log.debug("Unregister component {} for {}", serviceInstance.getClass().getName(), bundle.getSymbolicName());
+        bridge.getLocalComponents().remove(serviceInstance);
+        bundleContext.ungetService(reference);
+        bridge.markAsDirty();
+      }
+    }
+    super.removedService(reference, service);
+  }
+
+  private boolean isJaxRsComponent(Object serviceInstance) {
+    return (serviceInstance instanceof JaxRsComponent && hasAnyJaxRsAnnotation(serviceInstance.getClass()));
+  }
+
+  private boolean hasAnyJaxRsAnnotation(Class<?> clazz) {
+    return clazz.isAnnotationPresent(Path.class)
+        || clazz.isAnnotationPresent(Provider.class)
+        || clazz.isAnnotationPresent(PreMatching.class);
+  }
+
+}

--- a/publisher/src/main/java/io/wcm/caravan/jaxrs/publisher/package-info.java
+++ b/publisher/src/main/java/io/wcm/caravan/jaxrs/publisher/package-info.java
@@ -20,5 +20,5 @@
 /**
  * Publishes OSGi services as JAX-RS RESTful services.
  */
-@org.osgi.annotation.versioning.Version("1.0.0")
+@org.osgi.annotation.versioning.Version("1.1.0")
 package io.wcm.caravan.jaxrs.publisher;

--- a/publisher/src/test/java/io/wcm/caravan/jaxrs/publisher/impl/JaxRsApplicationTest.java
+++ b/publisher/src/test/java/io/wcm/caravan/jaxrs/publisher/impl/JaxRsApplicationTest.java
@@ -35,6 +35,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 import com.google.common.collect.ImmutableSet;
 
+import io.wcm.caravan.jaxrs.publisher.JaxRsClassesProvider;
 import io.wcm.caravan.jaxrs.publisher.JaxRsComponent;
 
 
@@ -45,11 +46,16 @@ public class JaxRsApplicationTest {
   private JaxRsComponent localComponent;
   @Mock
   private JaxRsComponent globalComponent;
+  @Mock
+  private JaxRsClassesProvider localClassesProvider;
+  @Mock
+  private JaxRsClassesProvider globalClassesProvider;
 
   @Test
   public void test_getSingletons() throws Exception {
 
-    JaxRsApplication app = new JaxRsApplication(ImmutableSet.of(localComponent), ImmutableSet.of(globalComponent));
+    JaxRsApplication app = new JaxRsApplication(ImmutableSet.of(localComponent), ImmutableSet.of(globalComponent),
+        ImmutableSet.of(localClassesProvider), ImmutableSet.of(globalClassesProvider));
     Set<Object> singletons = app.getSingletons();
 
     assertEquals(2, singletons.size());
@@ -60,10 +66,11 @@ public class JaxRsApplicationTest {
   @Test
   public void test_getClasses_from_local_components() throws Exception {
 
-    when(localComponent.getAdditionalJaxRsClassesToRegister())
+    when(localClassesProvider.getClasses())
         .thenReturn(ImmutableSet.of(AdditionalResource.class));
 
-    JaxRsApplication app = new JaxRsApplication(ImmutableSet.of(localComponent), ImmutableSet.of(globalComponent));
+    JaxRsApplication app = new JaxRsApplication(ImmutableSet.of(localComponent), ImmutableSet.of(globalComponent),
+        ImmutableSet.of(localClassesProvider), ImmutableSet.of(globalClassesProvider));
     Set<Class<?>> additionalClasses = app.getClasses();
 
     assertEquals(1, additionalClasses.size());
@@ -73,10 +80,11 @@ public class JaxRsApplicationTest {
   @Test
   public void test_getClasses_from_global_components() throws Exception {
 
-    when(globalComponent.getAdditionalJaxRsClassesToRegister())
+    when(globalClassesProvider.getClasses())
         .thenReturn(ImmutableSet.of(AdditionalResource.class));
 
-    JaxRsApplication app = new JaxRsApplication(ImmutableSet.of(localComponent), ImmutableSet.of(globalComponent));
+    JaxRsApplication app = new JaxRsApplication(ImmutableSet.of(localComponent), ImmutableSet.of(globalComponent),
+        ImmutableSet.of(localClassesProvider), ImmutableSet.of(globalClassesProvider));
     Set<Class<?>> additionalClasses = app.getClasses();
 
     assertEquals(1, additionalClasses.size());

--- a/publisher/src/test/java/io/wcm/caravan/jaxrs/publisher/impl/JaxRsApplicationTest.java
+++ b/publisher/src/test/java/io/wcm/caravan/jaxrs/publisher/impl/JaxRsApplicationTest.java
@@ -1,0 +1,94 @@
+/*
+ * #%L
+ * wcm.io
+ * %%
+ * Copyright (C) 2019 wcm.io
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package io.wcm.caravan.jaxrs.publisher.impl;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+
+import java.util.Set;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import com.google.common.collect.ImmutableSet;
+
+import io.wcm.caravan.jaxrs.publisher.JaxRsComponent;
+
+
+@RunWith(MockitoJUnitRunner.class)
+public class JaxRsApplicationTest {
+
+  @Mock
+  private JaxRsComponent localComponent;
+  @Mock
+  private JaxRsComponent globalComponent;
+
+  @Test
+  public void test_getSingletons() throws Exception {
+
+    JaxRsApplication app = new JaxRsApplication(ImmutableSet.of(localComponent), ImmutableSet.of(globalComponent));
+    Set<Object> singletons = app.getSingletons();
+
+    assertEquals(2, singletons.size());
+    assertTrue(singletons.contains(localComponent));
+    assertTrue(singletons.contains(globalComponent));
+  }
+
+  @Test
+  public void test_getClasses_from_local_components() throws Exception {
+
+    when(localComponent.getAdditionalJaxRsClassesToRegister())
+        .thenReturn(ImmutableSet.of(AdditionalResource.class));
+
+    JaxRsApplication app = new JaxRsApplication(ImmutableSet.of(localComponent), ImmutableSet.of(globalComponent));
+    Set<Class<?>> additionalClasses = app.getClasses();
+
+    assertEquals(1, additionalClasses.size());
+    assertTrue(additionalClasses.contains(AdditionalResource.class));
+  }
+
+  @Test
+  public void test_getClasses_from_global_components() throws Exception {
+
+    when(globalComponent.getAdditionalJaxRsClassesToRegister())
+        .thenReturn(ImmutableSet.of(AdditionalResource.class));
+
+    JaxRsApplication app = new JaxRsApplication(ImmutableSet.of(localComponent), ImmutableSet.of(globalComponent));
+    Set<Class<?>> additionalClasses = app.getClasses();
+
+    assertEquals(1, additionalClasses.size());
+    assertTrue(additionalClasses.contains(AdditionalResource.class));
+  }
+
+  @Path("/foo")
+  static class AdditionalResource {
+
+    @GET
+    public String get() {
+      return "bar";
+    }
+  }
+}


### PR DESCRIPTION
The current JAX-RS integration requires all resources (and providers or features) to be OSGI components, so that they are automatically registered to the JaxRsApplication, but sometimes it is desired to have non-OSGI resource classes, for which the lifecycle and dependency injection is completely managed by the JAX-RS runtime. 

One example are request-scoped resources, that can use constructor initialisation with @QueryParam and @BeanParam annotations in the constructor parameters.

This PR adds the possibility to register any other class, by optionally implementing #getAdditionalJaxRsClassesToRegister() in any of your JaxRsComponent services. The JaxRsApplication will collect these  additional classes from all local and global components, and return them in #getClasses().

It would be more convienient to have some "automatic" registration for such classes (e.g. classpath scanning), I don't see how this would be easily possible without introducing additional dependencies.

