### PR TITLE
Enable Build with Java 17, use Java 17 for Sonar Analysis

### DIFF
--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        java: [11]
+        java: [11, 17]
         os: [ubuntu-latest]
         distribution: [temurin]
 
@@ -31,6 +31,6 @@ jobs:
           os: ${{ matrix.os }}
           java-version: ${{ matrix.java }}
           sonar-run-on-os: ubuntu-latest
-          sonar-run-on-java-version: 11
+          sonar-run-on-java-version: 17
           sonar-token: ${{ secrets.SONAR_TOKEN }}
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/examples/aem-caravan-jaxrs-sample/bundles/core/pom.xml
+++ b/examples/aem-caravan-jaxrs-sample/bundles/core/pom.xml
@@ -32,7 +32,7 @@
   <groupId>io.wcm.caravan.samples</groupId>
   <artifactId>io.wcm.caravan.samples.aem-caravan-jaxrs-sample.core</artifactId>
   <version>1.0.0-SNAPSHOT</version>
-  <packaging>bundle</packaging>
+  <packaging>jar</packaging>
 
   <name>aem-caravan-jaxrs-sample Core</name>
 
@@ -70,12 +70,21 @@
       </plugin>
 
       <plugin>
-        <groupId>org.apache.felix</groupId>
-        <artifactId>maven-bundle-plugin</artifactId>
+        <groupId>biz.aQute.bnd</groupId>
+        <artifactId>bnd-maven-plugin</artifactId>
         <configuration>
-          <instructions>
-            <Caravan-JaxRs-ApplicationPath>/aem-caravan-jaxrs-sample</Caravan-JaxRs-ApplicationPath>
-          </instructions>
+          <bnd>
+            Caravan-JaxRs-ApplicationPath: /aem-caravan-jaxrs-sample
+          </bnd>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+          </archive>
         </configuration>
       </plugin>
 

--- a/examples/aem-caravan-jaxrs-sample/parent/pom.xml
+++ b/examples/aem-caravan-jaxrs-sample/parent/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>io.wcm.maven</groupId>
     <artifactId>io.wcm.maven.aem-global-parent</artifactId>
-    <version>1.2.34</version>
+    <version>2.1.16</version>
     <relativePath/>
   </parent>
 
@@ -41,7 +41,10 @@
 
     <!-- Sling instance parameters -->
     <sling.url>http://localhost:4502</sling.url>
-    
+
+    <!-- Enable reproducible builds -->
+    <project.build.outputTimestamp>2024-01-01T00:00:00Z</project.build.outputTimestamp>
+
   </properties>
 
   <dependencies>

--- a/integration-test/launchpad-test/pom.xml
+++ b/integration-test/launchpad-test/pom.xml
@@ -208,6 +208,7 @@
           </execution>
         </executions>
         <configuration>
+          <skipLaunchpad>${integrationtests.skip}</skipLaunchpad>
           <usePomDependencies>true</usePomDependencies>
           <usePomVariables>true</usePomVariables>
           <servers>
@@ -315,6 +316,17 @@
         <launchpad.debug>true</launchpad.debug>
         <http.port>8080</http.port>
       </properties>            
+    </profile>
+
+    <!-- Skip Integration tests on Java 17 and 21 until we upgraded to latest Sling Starter -->
+    <profile>
+      <id>skip-java17</id>
+      <activation>
+        <jdk>[17,)</jdk>
+      </activation>
+      <properties>
+        <integrationtests.skip>true</integrationtests.skip>
+      </properties>
     </profile>
 
   </profiles>


### PR DESCRIPTION
 Skip Integration tests on Java 17 and 21 until we upgraded to latest Sling Starter