### PR TITLE
AEM as a Cloud Service: components and services request in dev.tools are not working

### DIFF
--- a/publisher/changes.xml
+++ b/publisher/changes.xml
@@ -23,6 +23,12 @@
     xsi:schemaLocation="http://maven.apache.org/changes/1.0.0 http://maven.apache.org/plugins/maven-changes-plugin/xsd/changes-1.0.0.xsd">
   <body>
 
+    <release version="1.2.2" date="not released">
+      <action type="fix" dev="iakulenka" issue="4">
+        Fix issue with AEMaaCS: Use bundle ID instead of bundle instance to pass over bundle reference to ServletContainerBridge.
+      </action>
+    </release>
+
     <release version="1.2.0" date="2019-06-03">
       <action type="add" dev="ssauder">
         Add new interface "JaxRsClassesProvider" to allow to register additional resources, providers and features that are not OSGi components.

--- a/publisher/src/main/java/io/wcm/caravan/jaxrs/publisher/impl/JaxRsBundleTracker.java
+++ b/publisher/src/main/java/io/wcm/caravan/jaxrs/publisher/impl/JaxRsBundleTracker.java
@@ -80,7 +80,7 @@ public class JaxRsBundleTracker implements BundleTrackerCustomizer<ComponentInst
       // register JAX-RS application as servlet on HTTP whiteboard
       Dictionary<String, Object> serviceConfig = new Hashtable<>();
       serviceConfig.put("alias", applicationPath);
-      serviceConfig.put(ServletContainerBridge.PROPERTY_BUNDLE, bundle);
+      serviceConfig.put(ServletContainerBridge.PROPERTY_BUNDLE_ID, bundle.getBundleId());
       return servletContainerBridgeFactory.newInstance(serviceConfig);
     }
     return null;

--- a/publisher/src/main/java/io/wcm/caravan/jaxrs/publisher/impl/ServletContainerBridge.java
+++ b/publisher/src/main/java/io/wcm/caravan/jaxrs/publisher/impl/ServletContainerBridge.java
@@ -60,7 +60,7 @@ public class ServletContainerBridge extends HttpServlet {
   private static final long serialVersionUID = 1L;
 
   static final String SERVLETCONTAINER_BRIDGE_FACTORY = "caravan.jaxrs.servletcontainer.bridge.factory";
-  static final String PROPERTY_BUNDLE = "caravan.jaxrs.relatedBundle";
+  static final String PROPERTY_BUNDLE_ID = "caravan.jaxrs.relatedBundleId";
 
   private BundleContext bundleContext;
   private Bundle bundle;
@@ -79,7 +79,8 @@ public class ServletContainerBridge extends HttpServlet {
   @Activate
   void activate(ComponentContext componentContext) {
     // bundle which contains the JAX-RS services
-    bundle = (Bundle)componentContext.getProperties().get(PROPERTY_BUNDLE);
+    bundle = componentContext.getBundleContext().getBundle(
+            (Long) componentContext.getProperties().get(PROPERTY_BUNDLE_ID));
     bundleContext = bundle.getBundleContext();
 
     // initialize component tracker to detect local and global JAX-RS components for current bundle

--- a/publisher/src/main/java/io/wcm/caravan/jaxrs/publisher/impl/ServletContainerBridge.java
+++ b/publisher/src/main/java/io/wcm/caravan/jaxrs/publisher/impl/ServletContainerBridge.java
@@ -80,7 +80,7 @@ public class ServletContainerBridge extends HttpServlet {
   void activate(ComponentContext componentContext) {
     // bundle which contains the JAX-RS services
     bundle = componentContext.getBundleContext().getBundle(
-            (Long) componentContext.getProperties().get(PROPERTY_BUNDLE_ID));
+        (Long)componentContext.getProperties().get(PROPERTY_BUNDLE_ID));
     bundleContext = bundle.getBundleContext();
 
     // initialize component tracker to detect local and global JAX-RS components for current bundle


### PR DESCRIPTION
Proposed fix description:
When the bundle tracker (JaxRsBundleTracker) registers ComponentFactory (i.e. ServletContainerBridge), there is
a dictionary created and a reference to the bundle is placed into this dictionary. This produces the error in AEM cloud manager.
This reference can be changed to bundle ID and some correspondent adjustments need to be taken.

Fixes #5 